### PR TITLE
[Feature] Separate PRs from Issues

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ curl -H "x-api-token:1234" http://127.0.0.1:8080/api/repos
       "forks": 1,
       "watchers": 110,
       "issues": 5,
+      "prs": 1,
       "clones_count": 90,
       "clones_uniques": 45,
       "views_count": 1726,

--- a/src/gh_client.rs
+++ b/src/gh_client.rs
@@ -24,6 +24,12 @@ pub struct Repo {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct PullRequest {
+  pub id: u64,
+  pub title: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct TrafficDaily {
   pub timestamp: String,
   pub uniques: u32,
@@ -126,6 +132,13 @@ impl GhClient {
     let url = format!("{}/user/repos?visibility=public", self.base_url);
     let req = self.client.get(url);
     let dat: Vec<Repo> = self.with_pagination(req).await?;
+    Ok(dat)
+  }
+
+  pub async fn get_open_pull_requests(&self, repo: &str) -> Res<Vec<PullRequest>> {
+    let url = format!("{}/repos/{}/pulls?state=open", self.base_url, repo);
+    let req = self.client.get(url);
+    let dat: Vec<PullRequest> = self.with_pagination(req).await?;
     Ok(dat)
   }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -53,13 +53,17 @@ pub async fn update_metrics(db: &DbClient, gh: &GhClient) -> Res {
 }
 
 async fn update_repo_metrics(db: &DbClient, gh: &GhClient, repo: &Repo, date: &str) -> Res {
+  let prs = gh.get_open_pull_requests(&repo.full_name).await?;
   let views = gh.traffic_views(&repo.full_name).await?;
   let clones = gh.traffic_clones(&repo.full_name).await?;
   let referrers = gh.traffic_refs(&repo.full_name).await?;
+
   let popular_paths = gh.traffic_paths(&repo.full_name).await?;
 
   db.insert_repo(&repo).await?;
   db.insert_stats(&repo, date).await?;
+  db.insert_issues(&repo, date, &prs).await?;
+  db.insert_prs(&repo, date, &prs).await?;
   db.insert_views(&repo, &views).await?;
   db.insert_clones(&repo, &clones).await?;
   db.insert_referrers(&repo, date, &referrers).await?;

--- a/src/routes/html.rs
+++ b/src/routes/html.rs
@@ -355,6 +355,7 @@ pub async fn index(State(state): State<Arc<AppState>>, req: Request) -> HtmlRes 
   let cols: Vec<(&str, Box<dyn Fn(&RepoTotals) -> Markup>, RepoSort)> = vec![
     ("Name", Box::new(|x| html!(a href=(format!("/{}", x.name)) { (x.name) })), RepoSort::Name),
     ("Issues", Box::new(|x| html!((x.issues.separate_with_commas()))), RepoSort::Issues),
+    ("PRs", Box::new(|x| html!((x.prs.separate_with_commas()))), RepoSort::Prs),
     ("Forks", Box::new(|x| html!((x.forks.separate_with_commas()))), RepoSort::Forks),
     ("Clones", Box::new(|x| html!((x.clones_count.separate_with_commas()))), RepoSort::Clones),
     ("Stars", Box::new(|x| html!((x.stars.separate_with_commas()))), RepoSort::Stars),


### PR DESCRIPTION
1. New request to get open PRs.
2. Calculate open Issues based on `open_issues_count` and `prs`.
3. Update db structure: new `prs` column in `repo_stats` table to hold PRs value.
4. Update db migration to not brake current db structure.