### PR TITLE
Add search and owner filtering to repos table

### DIFF
--- a/src/db_client.rs
+++ b/src/db_client.rs
@@ -257,6 +257,8 @@ impl std::fmt::Display for PopularSort {
 pub struct RepoFilter {
   pub sort: RepoSort,
   pub direction: Direction,
+  pub q: Option<String>,
+  pub owner: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default)]

--- a/src/routes/html.rs
+++ b/src/routes/html.rs
@@ -349,6 +349,7 @@ pub async fn repo_page(
 pub async fn index(State(state): State<Arc<AppState>>, req: Request) -> HtmlRes {
   // let qs: Query<HashMap<String, String>> = Query::try_from_uri(req.uri())?;
   let qs: Query<RepoFilter> = Query::try_from_uri(req.uri())?;
+  let owners = state.get_owners().await?;
   let repos = state.get_repos_filtered(&qs).await?;
 
   let cols: Vec<(&str, Box<dyn Fn(&RepoTotals) -> Markup>, RepoSort)> = vec![
@@ -367,10 +368,24 @@ pub async fn index(State(state): State<Arc<AppState>>, req: Request) -> HtmlRes 
       false => "desc",
     };
 
-    format!("/?sort={}&direction={}", col, dir)
+    let mut url = format!("/?sort={}&direction={}", col, dir);
+    if let Some(q) = &qs.q {
+      if !q.is_empty() {
+        url.push_str(&format!("&q={}", q));
+      }
+    }
+    if let Some(owner) = &qs.owner {
+      if !owner.is_empty() {
+        url.push_str(&format!("&owner={}", owner));
+      }
+    }
+    url
   }
 
-  let html = html!(
+  let cur_q = qs.q.clone().unwrap_or_default();
+  let cur_owner = qs.owner.clone().unwrap_or_default();
+
+  let table_html = html!(
       table id="repos_table" {
         thead {
           tr {
@@ -404,9 +419,40 @@ pub async fn index(State(state): State<Arc<AppState>>, req: Request) -> HtmlRes 
   );
 
   match get_hx_target(&req) {
-    Some("repos_table") => return Ok(html),
+    Some("repos_table") => return Ok(table_html),
     _ => {}
   }
+
+  let html = html!(
+    div class="flex-row gap-4 mb-0" {
+      @if owners.len() > 1 {
+        select name="owner" class="mb-0"
+          style="width: auto;"
+          hx-get=(format!("/?sort={}&direction={}", qs.sort, qs.direction))
+          hx-target="#repos_table"
+          hx-swap="outerHTML"
+          hx-include="[name='q']"
+        {
+          option value="" selected[cur_owner.is_empty()] { "All owners" }
+          @for owner in &owners {
+            option value=(owner) selected[*owner == cur_owner] { (owner) }
+          }
+        }
+      }
+
+      input type="search" name="q" value=(cur_q)
+        placeholder="Search repos…"
+        class="mb-0"
+        hx-get=(format!("/?sort={}&direction={}", qs.sort, qs.direction))
+        hx-trigger="keyup changed delay:300ms, search"
+        hx-target="#repos_table"
+        hx-swap="outerHTML"
+        hx-include="[name='owner']"
+      {}
+    }
+
+    (table_html)
+  );
 
   Ok(base(&state, vec![], html))
 }

--- a/src/routes/html.rs
+++ b/src/routes/html.rs
@@ -427,7 +427,7 @@ pub async fn index(State(state): State<Arc<AppState>>, req: Request) -> HtmlRes 
     div class="flex-row gap-4 mb-0" {
       @if owners.len() > 1 {
         select name="owner" class="mb-0"
-          style="width: auto;"
+          style="width: auto; height: calc(1.5em + 0.5rem + 2px); padding: 0.25rem 2rem 0.25rem 0.5rem; background-position: center right 0.25rem; background-size: 0.75rem auto;"
           hx-get=(format!("/?sort={}&direction={}", qs.sort, qs.direction))
           hx-target="#repos_table"
           hx-swap="outerHTML"
@@ -443,6 +443,7 @@ pub async fn index(State(state): State<Arc<AppState>>, req: Request) -> HtmlRes 
       input type="search" name="q" value=(cur_q)
         placeholder="Search repos…"
         class="mb-0"
+        style="padding: 0.25rem 0.5rem 0.25rem 2.75rem; height: auto;"
         hx-get=(format!("/?sort={}&direction={}", qs.sort, qs.direction))
         hx-trigger="keyup changed delay:300ms, search"
         hx-target="#repos_table"

--- a/src/routes/html.rs
+++ b/src/routes/html.rs
@@ -418,20 +418,28 @@ pub async fn index(State(state): State<Arc<AppState>>, req: Request) -> HtmlRes 
       }
   );
 
+  let sort_inputs = html!(
+    input type="hidden" id="filter_sort" name="sort" value=(qs.sort) hx-swap-oob="true" {}
+    input type="hidden" id="filter_direction" name="direction" value=(qs.direction) hx-swap-oob="true" {}
+  );
+
   match get_hx_target(&req) {
-    Some("repos_table") => return Ok(table_html),
+    Some("repos_table") => return Ok(html!((table_html) (sort_inputs))),
     _ => {}
   }
 
   let html = html!(
     div class="flex-row gap-4 mb-0" {
+      input type="hidden" id="filter_sort" name="sort" value=(qs.sort) {}
+      input type="hidden" id="filter_direction" name="direction" value=(qs.direction) {}
+
       @if owners.len() > 1 {
         select name="owner" class="mb-0"
           style="width: auto; height: calc(1.5em + 0.5rem + 2px); padding: 0.25rem 2rem 0.25rem 0.5rem; background-position: center right 0.25rem; background-size: 0.75rem auto;"
-          hx-get=(format!("/?sort={}&direction={}", qs.sort, qs.direction))
+          hx-get="/"
           hx-target="#repos_table"
           hx-swap="outerHTML"
-          hx-include="[name='q']"
+          hx-include="[name='q'], #filter_sort, #filter_direction"
         {
           option value="" selected[cur_owner.is_empty()] { "All owners" }
           @for owner in &owners {
@@ -444,11 +452,11 @@ pub async fn index(State(state): State<Arc<AppState>>, req: Request) -> HtmlRes 
         placeholder="Search repos…"
         class="mb-0"
         style="padding: 0.25rem 0.5rem 0.25rem 2.75rem; height: auto;"
-        hx-get=(format!("/?sort={}&direction={}", qs.sort, qs.direction))
+        hx-get="/"
         hx-trigger="keyup changed delay:300ms, search"
         hx-target="#repos_table"
         hx-swap="outerHTML"
-        hx-include="[name='owner']"
+        hx-include="[name='owner'], #filter_sort, #filter_direction"
       {}
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -47,7 +47,37 @@ impl AppState {
   pub async fn get_repos_filtered(&self, qs: &RepoFilter) -> Res<Vec<RepoTotals>> {
     let repos = self.db.get_repos(&qs).await?;
     let repos = repos.into_iter().filter(|x| self.filter.is_included(&x.name, x.fork, x.archived));
-    let repos = repos.collect::<Vec<_>>();
+
+    let repos: Vec<RepoTotals> = match &qs.q {
+      Some(q) if !q.is_empty() => {
+        let q = q.to_lowercase();
+        repos.filter(|x| x.name.to_lowercase().contains(&q)).collect()
+      }
+      _ => repos.collect(),
+    };
+
+    let repos: Vec<RepoTotals> = match &qs.owner {
+      Some(owner) if !owner.is_empty() => {
+        repos.into_iter().filter(|x| {
+          x.name.split('/').next().map_or(false, |o| o == owner)
+        }).collect()
+      }
+      _ => repos,
+    };
+
     Ok(repos)
+  }
+
+  pub async fn get_owners(&self) -> Res<Vec<String>> {
+    let filter = RepoFilter::default();
+    let repos = self.db.get_repos(&filter).await?;
+    let mut owners: Vec<String> = repos
+      .iter()
+      .filter(|x| self.filter.is_included(&x.name, x.fork, x.archived))
+      .filter_map(|x| x.name.split('/').next().map(|s| s.to_string()))
+      .collect();
+    owners.sort();
+    owners.dedup();
+    Ok(owners)
   }
 }


### PR DESCRIPTION
Adds filtering controls above the repos table on the home page:

- Text search input (case-insensitive substring match on repo name, 300ms debounce via HTMX)
- Owner/org dropdown (filters by `owner/` prefix, only shown when more than one owner exist)

Both filters compose with each other and preserve the current sort column/direction across interactions using hidden inputs with HTMX out-of-band swaps. The REST API also accepts the new `q` and `owner` query parameters.

<img width="1848" height="1042" alt="image" src="https://github.com/user-attachments/assets/907ce4bd-5d31-4953-a2b2-e0941ce7b8b0" />

Closes #22