### PR TITLE
fix: sync URL on filter changes so browser back/forward works

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,150 +1,156 @@
-// https://stackoverflow.com/a/68140000/3664464
-const mouseLinePlugin = {
-  afterDraw: chart => {
-    if (!chart.tooltip?._active?.length) return;
-    let x = chart.tooltip._active[0].element.x;
-    let yAxis = chart.scales.y;
-    let ctx = chart.ctx;
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(x, yAxis.top);
-    ctx.lineTo(x, yAxis.bottom);
-    ctx.lineWidth = 1;
-    ctx.strokeStyle = 'rgba(0, 0, 255, 0.4)';
-    ctx.stroke();
-    ctx.restore();
-  },
-};
-
-const parseMetricDate = value => {
-  const [year, month, day] = value.split('T')[0].split('-').map(Number);
-  return new Date(Date.UTC(year, month - 1, day));
-};
-
-const formatDate = date =>
-  `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
-
-const getWeekStart = date => {
-  const start = new Date(date);
-  const day = start.getUTCDay();
-  const diff = day === 0 ? -6 : 1 - day;
-  start.setUTCDate(start.getUTCDate() + diff);
-  return start;
-};
-
-const getBucketKind = metrics => {
-  if (metrics.length <= 1) return 'day';
-  const first = parseMetricDate(metrics[0].date);
-  const last = parseMetricDate(metrics.at(-1).date);
-  const rangeDays = Math.ceil((last - first) / 86400000);
-
-  if (rangeDays <= 90) return 'day';
-  if (rangeDays <= 365) return 'week';
-  return 'month';
-};
-
-const groupMetrics = (metrics, uniqueCol, countCol) => {
-  const bucketKind = getBucketKind(metrics);
-  const buckets = new Map();
-
-  for (const metric of metrics) {
-    const date = parseMetricDate(metric.date);
-    let bucketStart;
-    let label;
-
-    if (bucketKind === 'month') {
-      bucketStart = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
-      label = `${bucketStart.getUTCFullYear()}-${String(bucketStart.getUTCMonth() + 1).padStart(2, '0')}`;
-    } else if (bucketKind === 'week') {
-      bucketStart = getWeekStart(date);
-      label = formatDate(bucketStart);
-    } else {
-      bucketStart = date;
-      label = formatDate(bucketStart);
-    }
-
-    const key = formatDate(bucketStart);
-    const current = buckets.get(key) ?? {
-      x: bucketStart,
-      label,
-      title: label,
-      unique: 0,
-      count: 0,
-    };
-
-    current.unique += metric[uniqueCol];
-    current.count += metric[countCol];
-    buckets.set(key, current);
-  }
-
-  const items = Array.from(buckets.values()).sort((a, b) => a.x - b.x);
-  if (bucketKind === 'week') {
-    for (const item of items) {
-      const bucketEnd = new Date(item.x);
-      bucketEnd.setUTCDate(bucketEnd.getUTCDate() + 6);
-      item.title = `${formatDate(item.x)} to ${formatDate(bucketEnd)}`;
-    }
-  }
-
-  return { bucketKind, items };
-};
-
-const renderMetrics = (canvasId, metrics, uniqueCol, countCol) => {
-  const ctx = document.getElementById(canvasId);
-  const grouped = groupMetrics(metrics, uniqueCol, countCol);
-  new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: grouped.items.map(x => x.x),
-      datasets: [
-        { label: 'Unique', data: grouped.items.map(x => x.unique), borderWidth: 0, borderRadius: 4 },
-        { label: 'Count', data: grouped.items.map(x => x.count), borderWidth: 0, borderRadius: 4 },
-      ],
+(() => {
+  // https://stackoverflow.com/a/68140000/3664464
+  const mouseLinePlugin = {
+    afterDraw: chart => {
+      if (!chart.tooltip?._active?.length) return;
+      let x = chart.tooltip._active[0].element.x;
+      let yAxis = chart.scales.y;
+      let ctx = chart.ctx;
+      ctx.save();
+      ctx.beginPath();
+      ctx.moveTo(x, yAxis.top);
+      ctx.lineTo(x, yAxis.bottom);
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = 'rgba(0, 0, 255, 0.4)';
+      ctx.stroke();
+      ctx.restore();
     },
-    options: {
-      responsive: true,
-      interaction: { mode: 'index' },
-      scales: {
-        x: { stacked: true, type: 'time', time: { tooltipFormat: 'yyyy-MM-dd' } },
-        y: { beginAtZero: true },
+  };
+
+  const parseMetricDate = value => {
+    const [year, month, day] = value.split('T')[0].split('-').map(Number);
+    return new Date(Date.UTC(year, month - 1, day));
+  };
+
+  const formatDate = date =>
+    `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
+
+  const getWeekStart = date => {
+    const start = new Date(date);
+    const day = start.getUTCDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    start.setUTCDate(start.getUTCDate() + diff);
+    return start;
+  };
+
+  const getBucketKind = metrics => {
+    if (metrics.length <= 1) return 'day';
+    const first = parseMetricDate(metrics[0].date);
+    const last = parseMetricDate(metrics.at(-1).date);
+    const rangeDays = Math.ceil((last - first) / 86400000);
+
+    if (rangeDays <= 90) return 'day';
+    if (rangeDays <= 365) return 'week';
+    return 'month';
+  };
+
+  const groupMetrics = (metrics, uniqueCol, countCol) => {
+    const bucketKind = getBucketKind(metrics);
+    const buckets = new Map();
+
+    for (const metric of metrics) {
+      const date = parseMetricDate(metric.date);
+      let bucketStart;
+      let label;
+
+      if (bucketKind === 'month') {
+        bucketStart = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+        label = `${bucketStart.getUTCFullYear()}-${String(bucketStart.getUTCMonth() + 1).padStart(2, '0')}`;
+      } else if (bucketKind === 'week') {
+        bucketStart = getWeekStart(date);
+        label = formatDate(bucketStart);
+      } else {
+        bucketStart = date;
+        label = formatDate(bucketStart);
+      }
+
+      const key = formatDate(bucketStart);
+      const current = buckets.get(key) ?? {
+        x: bucketStart,
+        label,
+        title: label,
+        unique: 0,
+        count: 0,
+      };
+
+      current.unique += metric[uniqueCol];
+      current.count += metric[countCol];
+      buckets.set(key, current);
+    }
+
+    const items = Array.from(buckets.values()).sort((a, b) => a.x - b.x);
+    if (bucketKind === 'week') {
+      for (const item of items) {
+        const bucketEnd = new Date(item.x);
+        bucketEnd.setUTCDate(bucketEnd.getUTCDate() + 6);
+        item.title = `${formatDate(item.x)} to ${formatDate(bucketEnd)}`;
+      }
+    }
+
+    return { bucketKind, items };
+  };
+
+  window.renderMetrics = (canvasId, metrics, uniqueCol, countCol) => {
+    const ctx = document.getElementById(canvasId);
+    if (!ctx) return;
+
+    const grouped = groupMetrics(metrics, uniqueCol, countCol);
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: grouped.items.map(x => x.x),
+        datasets: [
+          { label: 'Unique', data: grouped.items.map(x => x.unique), borderWidth: 0, borderRadius: 4 },
+          { label: 'Count', data: grouped.items.map(x => x.count), borderWidth: 0, borderRadius: 4 },
+        ],
       },
-      plugins: {
-        legend: { display: false },
-        // title: { display: true, text: uniqueCol.split('_')[0].toUpperCase() }
-        tooltip: {
-          intersect: false,
-          callbacks: {
-            title: items => grouped.items[items[0].dataIndex]?.title ?? '',
+      options: {
+        responsive: true,
+        interaction: { mode: 'index' },
+        scales: {
+          x: { stacked: true, type: 'time', time: { tooltipFormat: 'yyyy-MM-dd' } },
+          y: { beginAtZero: true },
+        },
+        plugins: {
+          legend: { display: false },
+          // title: { display: true, text: uniqueCol.split('_')[0].toUpperCase() }
+          tooltip: {
+            intersect: false,
+            callbacks: {
+              title: items => grouped.items[items[0].dataIndex]?.title ?? '',
+            },
           },
         },
       },
-    },
-    plugins: [mouseLinePlugin],
-  });
-};
+      plugins: [mouseLinePlugin],
+    });
+  };
 
-const renderStars = (canvasId, stars) => {
-  const ctx = document.getElementById(canvasId);
-  new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: stars.map(x => x.date.split('T')[0]),
-      datasets: [{ label: '', data: stars.map(x => x.stars), pointStyle: false, tension: 0.0 }],
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      interaction: { mode: 'index' },
-      scales: {
-        x: { stacked: true, type: 'time', time: { tooltipFormat: 'yyyy-MM-dd' } },
-        y: { beginAtZero: true },
+  window.renderStars = (canvasId, stars) => {
+    const ctx = document.getElementById(canvasId);
+    if (!ctx) return;
+
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: stars.map(x => x.date.split('T')[0]),
+        datasets: [{ label: '', data: stars.map(x => x.stars), pointStyle: false, tension: 0.0 }],
       },
-      plugins: {
-        legend: { display: false },
-        title: { display: false, text: 'Stars', font: { size: 20 }, align: 'start' },
-        tooltip: { intersect: false },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index' },
+        scales: {
+          x: { stacked: true, type: 'time', time: { tooltipFormat: 'yyyy-MM-dd' } },
+          y: { beginAtZero: true },
+        },
+        plugins: {
+          legend: { display: false },
+          title: { display: false, text: 'Stars', font: { size: 20 }, align: 'start' },
+          tooltip: { intersect: false },
+        },
       },
-    },
-    plugins: [mouseLinePlugin],
-  });
-};
+      plugins: [mouseLinePlugin],
+    });
+  };
+})();

--- a/src/routes/html.rs
+++ b/src/routes/html.rs
@@ -124,6 +124,8 @@ fn base(state: &Arc<AppState>, navs: Vec<(String, Option<String>)>, inner: Marku
         script src="https://unpkg.com/luxon@3.5" {}
         script src="https://unpkg.com/chartjs-adapter-luxon@1.3" {}
         script src="https://unpkg.com/htmx.org@2.0" {}
+        script { "htmx.config.historyCacheSize = 0;" }
+        script { (PreEscaped(include_str!("../../assets/app.js"))) }
         style { (PreEscaped(include_str!("../../assets/app.css"))) }
       }
       body {
@@ -352,13 +354,14 @@ pub async fn repo_page(
       }
     }
 
-    script { (PreEscaped(include_str!("../../assets/app.js"))) }
     script {
-      "const Metrics = "(PreEscaped(serde_json::to_string(&metrics)?))";"
-      "const Stars = "(PreEscaped(serde_json::to_string(&stars)?))";"
-      "renderMetrics('chart_clones', Metrics, 'clones_uniques', 'clones_count');"
-      "renderMetrics('chart_views', Metrics, 'views_uniques', 'views_count');"
-      "renderStars('chart_stars', Stars);"
+      "(function() {"
+      "const metrics = "(PreEscaped(serde_json::to_string(&metrics)?))";"
+      "const stars = "(PreEscaped(serde_json::to_string(&stars)?))";"
+      "window.renderMetrics('chart_clones', metrics, 'clones_uniques', 'clones_count');"
+      "window.renderMetrics('chart_views', metrics, 'views_uniques', 'views_count');"
+      "window.renderStars('chart_stars', stars);"
+      "})();"
     }
 
     select name="period" hx-get=(format!("/{}", repo)) hx-target="#popular_tables" hx-swap="outerHTML" hx-push-url="true" {

--- a/src/routes/html.rs
+++ b/src/routes/html.rs
@@ -231,6 +231,7 @@ async fn popular_table(
                 hx-get=(filter_url(repo, qs, &col.2))
                 hx-target=(format!("#{}", html_id))
                 hx-swap="outerHTML"
+                hx-replace-url="true"
               {
                 (col.0)
                 @if col.2 == qs.sort {
@@ -360,7 +361,7 @@ pub async fn repo_page(
       "renderStars('chart_stars', Stars);"
     }
 
-    select name="period" hx-get=(format!("/{}", repo)) hx-target="#popular_tables" hx-swap="outerHTML" {
+    select name="period" hx-get=(format!("/{}", repo)) hx-target="#popular_tables" hx-swap="outerHTML" hx-push-url="true" {
       @for (days, title) in &periods {
         option value=(days) selected[*days == qs.period] { (title) }
       }
@@ -428,6 +429,7 @@ pub async fn index(
                 hx-get=(filter_url(&qs, &col.2))
                 hx-target="#repos_table"
                 hx-swap="outerHTML"
+                hx-replace-url="true"
                 {
                   (col.0)
                   @if col.2 == qs.sort {
@@ -472,6 +474,7 @@ pub async fn index(
           hx-target="#repos_table"
           hx-swap="outerHTML"
           hx-include="[name='q'], #filter_sort, #filter_direction"
+          hx-push-url="true"
         {
           option value="" selected[cur_owner.is_empty()] { "All owners" }
           @for owner in &owners {
@@ -489,6 +492,7 @@ pub async fn index(
         hx-target="#repos_table"
         hx-swap="outerHTML"
         hx-include="[name='owner'], #filter_sort, #filter_direction"
+        hx-replace-url="true"
       {}
     }
 


### PR DESCRIPTION
The owner select, search input, sort headers, and period select updated the table via HTMX but never touched the URL. As a result, visiting a repo detail page and hitting browser Back caused the server to re-render the index fresh — the filter was gone and the pulldown reverted to "All owners".

This change adds `hx-push-url="true"` to the discrete actions (owner, period) and `hx-replace-url="true"` to the noisy ones (search keystrokes, sort clicks), so the URL stays in sync with the current filter state without flooding history with one entry per keystroke.